### PR TITLE
Add dependencies on the deluge user and packages so services are started

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,18 +28,20 @@ class deluge {
 
     file {
         '/etc/init/deluged.conf':
-            ensure => file,
-            mode   => '0644',
-            owner  => root,
-            group  => root,
-            source => 'puppet:///modules/deluge/deluged.conf';
+            ensure  => file,
+            mode    => '0644',
+            owner   => root,
+            group   => root,
+            source  => 'puppet:///modules/deluge/deluged.conf',
+            require => [Package['deluged'], User['deluge']];
 
         '/etc/init/deluge-web.conf':
-            ensure => file,
-            mode   => '0644',
-            owner  => root,
-            group  => root,
-            source => 'puppet:///modules/deluge/deluge-web.conf';
+            ensure  => file,
+            mode    => '0644',
+            owner   => root,
+            group   => root,
+            source  => 'puppet:///modules/deluge/deluge-web.conf',
+            require => [Package['deluge-web'], User['deluge']];
 
         '/var/log/deluge':
             ensure => directory,


### PR DESCRIPTION
The files in /etc/init require the deluge user and the deluged/deluge-web
packages to function, but did not declare a puppet dependency on these
resources. This resulted in the deluged/deluge-web services failing to start
after applying this class for the first time.
