### PR TITLE
Enable deluge services

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,11 +54,13 @@ class deluge {
     service {
         'deluged':
             ensure     => running,
+            enable     => true,
             provider   => upstart,
             subscribe  => File['/etc/init/deluged.conf'];
 
         'deluge-web':
             ensure     => running,
+            enable     => true,
             provider   => upstart,
             subscribe  => File['/etc/init/deluge-web.conf'];
 


### PR DESCRIPTION
Setting the `enable` parameter ensures that when deluge starts up correctly when the machine is restarted.

I included a commit which fixes some whitespace so that the service parameter values line up like the rest of the file, but I can remove that commit if you don't want it :)
