### PR TITLE
Use `static-network-up` instead of `stopped networking` in upstart script

### DIFF
--- a/files/deluged.conf
+++ b/files/deluged.conf
@@ -6,7 +6,7 @@
 description "Deluge daemon"
 author "Deluge Team"
 
-start on filesystem and stopped networking
+start on filesystem and static-network-up
 stop on runlevel [016]
 
 respawn


### PR DESCRIPTION
This works on ubuntu oneiric (11.10) and above, and fixes the behaviour for ubuntu quantal (12.10) and above which no longer fire `stopped networking` during startup.

Upstart cookbook bug describing the issue: https://bugs.launchpad.net/upstart-cookbook/+bug/1222004

If you need to support ubuntu versions older than 11.10 then some version sniffing will need to be added to use `stopped networking` on old versions and `static-network-up` on new versions.